### PR TITLE
Alert component name should start with capital letter for consistenty

### DIFF
--- a/packages/wingsuit/source/default/patterns/01-atoms/alert/alert.wingsuit.yml
+++ b/packages/wingsuit/source/default/patterns/01-atoms/alert/alert.wingsuit.yml
@@ -1,6 +1,6 @@
 alert:
   use: "@atoms/alert/alert.twig"
-  label: alert
+  label: Alert
   description: Example description
   fields:
     header:


### PR DESCRIPTION
Just testing the waters with setting up the project locally for development and this simple pull request.
