### PR TITLE
CSS vendor prefixes are not needed as they are auto-generated

### DIFF
--- a/packages/wingsuit/source/default/patterns/02-molecules/accordion-item/accordion-item.css
+++ b/packages/wingsuit/source/default/patterns/02-molecules/accordion-item/accordion-item.css
@@ -1,7 +1,5 @@
 .tab-content {
   max-height: 0;
-  -webkit-transition: max-height .35s;
-  -o-transition: max-height .35s;
   transition: max-height .35s;
 }
 /* :checked - resize to full height */


### PR DESCRIPTION
they are auto-generated with postcss