### PR TITLE
Running "attachBehaviors" after react component is rendered

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,7 @@ module.exports = {
   extends: ['@storybook/eslint-config-storybook'],
   overrides: [
     {
-      files: [
-        '**/__tests__/**',
-        '**/__testfixtures__/**',
-        '**/*.test.*',
-        '**/*.stories.*'
-      ],
+      files: ['**/__tests__/**', '**/__testfixtures__/**', '**/*.test.*', '**/*.stories.*'],
       rules: {
         '@typescript-eslint/no-empty-function': 'off',
         'import/no-extraneous-dependencies': 'off',
@@ -34,6 +29,7 @@ module.exports = {
       rules: {
         'react/prop-types': 'off', // we should use types
         'no-dupe-class-members': 'off', // this is called overloads in typescript
+        'no-console': ["error", { allow: ["warn", "error"] }] ,
       },
     },
     {

--- a/examples/official-wingsuit/.eslintrc.js
+++ b/examples/official-wingsuit/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     'plugin:vue/recommended',
     'plugin:prettier/recommended',
     'prettier/vue',
-    "plugin:react/recommended"
+    'plugin:react/recommended',
   ],
   plugins: ['prettier'],
   root: true,
@@ -42,22 +42,25 @@ module.exports = {
     node: true,
   },
   rules: {
-    "react/jsx-uses-react": 1,
-    "prettier/prettier": ["error", {
-      "endOfLine":"auto"
-    }],
+    'react/jsx-uses-react': 1,
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'no-console': [0], // turned off for now while we are console.logging everywhere.
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
-    'import/prefer-default-export': [0]
+    'import/prefer-default-export': [0],
   },
-  "settings": {
-    "react": {
-      "version": "detect",
+  settings: {
+    react: {
+      version: 'detect',
     },
-    "import/resolver": {
-      "alias": {
-        map: aliasMap
-      }
-    }
-  }
+    'import/resolver': {
+      alias: {
+        map: aliasMap,
+      },
+    },
+  },
 };

--- a/examples/official-wingsuit/.eslintrc.js
+++ b/examples/official-wingsuit/.eslintrc.js
@@ -4,10 +4,19 @@
  * Rule reference: http://eslint.org/docs/rules
  * Individual rule reference: http://eslint.org/docs/rules/NAME-OF-RULE
  */
-const path = require('path');
-const namespaces = require('./source/default/namespaces');
+const wingsuitCore = require('@wingsuit-designsystem/core');
+const wingsuitConfig = require('./wingsuit.config');
+
+const appConfig = wingsuitCore.resolveConfig(
+  'storybook',
+  'development',
+  {},
+  wingsuitConfig,
+  __dirname
+);
+const { namespaces } = appConfig;
 const aliasMap = [];
-Object.keys(namespaces).forEach((key)=>{
+Object.keys(namespaces).forEach((key) => {
   aliasMap.push([key, namespaces[key]]);
 });
 

--- a/examples/official-wingsuit/apps/storybook/preview.js
+++ b/examples/official-wingsuit/apps/storybook/preview.js
@@ -1,18 +1,37 @@
-import { configure, drupalAttachBehaviorDecorator } from '@wingsuit-designsystem/storybook';
+import { configure, initJsBehaviors } from '@wingsuit-designsystem/storybook';
+import { addParameters } from '@storybook/react';
 
-import { addDecorator } from '@storybook/react';
+const namespaces = require('wsdesignsystem/namespaces');
 
-const namespaces = require('../../source/default/namespaces');
+initJsBehaviors('Drupal');
 
-addDecorator(drupalAttachBehaviorDecorator);
+addParameters({
+  options: {
+    storySort: {
+      method: 'alphabetical',
+      order: [
+        'Welcome',
+        'Layout',
+        'Tokens',
+        ['Colors', 'Typography', 'Scales'],
+        'Atoms',
+        'Molecules',
+        'Organisms',
+        'Templates',
+        'Pages',
+      ],
+      locales: 'en-US',
+    },
+  },
+});
 
 configure(
   module,
   [
     require.context('./patterns', true, /\.stories(\.jsx|\.js|\.mdx)$/),
-    require.context('../../source/default/patterns', true, /\.stories(\.jsx|\.js|\.mdx)$/),
+    require.context('wspatterns', true, /\.stories(\.jsx|\.js|\.mdx)$/),
   ],
-  require.context('./config', true, /\.json|\.ya?ml$/),
-  require.context('../../source/default/patterns', true, /\.twig$/),
+  require.context('./config', false, /\.json|\.ya?ml$/),
+  require.context('wspatterns', true, /\.twig$/),
   namespaces
 );

--- a/packages/cli/src/component.ts
+++ b/packages/cli/src/component.ts
@@ -2,7 +2,7 @@ const yeoman = require('yeoman-environment');
 
 const Generator = require.resolve('./generators/component');
 const env = yeoman.createEnv();
-export default function (options) {
+export default function(options) {
   env.register(Generator, 'ws:component');
   env.run('ws:component', () => {});
 }

--- a/packages/cli/src/generate.ts
+++ b/packages/cli/src/generate.ts
@@ -18,25 +18,25 @@ program
   .option('-N --use-npm', 'Use npm to install deps')
   .option('-S --smoke-test', 'Exit after successful start')
   .option('-B --branch <branch>', 'Use a specific branch')
-  .action((options) => initiate(options));
+  .action(options => initiate(options));
 
 program
   .command('version')
   .description('Shows Wingsuit version.')
-  .action((options) => version(options));
+  .action(options => version(options));
 
 program
   .command('generate-component')
   .description('Generate Wingsuit component.')
   .option('-N --use-npm', 'Use npm to install deps')
-  .action((options) => component(options));
+  .action(options => component(options));
 
 program.command('*', '').action(() => {
   const [, , invalidCmd] = process.argv;
   logger.error(' Invalid command: %s.\n See --help for a list of available commands.', invalidCmd);
   // eslint-disable-next-line
     const availableCommands = program.commands.map(cmd => cmd._name);
-  const suggestion = availableCommands.find((cmd) => leven(cmd, invalidCmd) < 3);
+  const suggestion = availableCommands.find(cmd => leven(cmd, invalidCmd) < 3);
   if (suggestion) {
     logger.log(`\n Did you mean ${suggestion}?`);
   }
@@ -44,7 +44,10 @@ program.command('*', '').action(() => {
   process.exit(1);
 });
 
-program.usage('<command> [options]').version('1').parse(process.argv);
+program
+  .usage('<command> [options]')
+  .version('1')
+  .parse(process.argv);
 
 if (program.rawArgs.length < 3) {
   program.help();

--- a/packages/cli/src/generators/component/index.ts
+++ b/packages/cli/src/generators/component/index.ts
@@ -49,7 +49,7 @@ export default class extends Generator {
           // Return array of atomic folders within the app's design system
           return readdirSync(`${config.absDesignSystemPath}/patterns`, {
             withFileTypes: true,
-          }).filter((folder) => folder.isDirectory());
+          }).filter(folder => folder.isDirectory());
         },
       },
       {
@@ -105,7 +105,7 @@ export default class extends Generator {
       },
     ];
 
-    return this.prompt(prompts).then((props) => {
+    return this.prompt(prompts).then(props => {
       // To access props later use this.props.someAnswer;
       const cleanPatternType = props.patternType.replace(/([0-9])\w+-/g, '');
       this.props = {
@@ -140,7 +140,7 @@ export default class extends Generator {
     // Convert 'patterns.twig.ejs' to 'cards.twig'. registerTransformStream is
     // a reserved method to which Yeoman provides all file streams from copyTpl()
     this.registerTransformStream(
-      rename((path) => {
+      rename(path => {
         // Remove extension and replace pattern with pattern name
         path.basename = path.basename.replace('pattern', name);
         return path;

--- a/packages/cli/src/initiate.ts
+++ b/packages/cli/src/initiate.ts
@@ -8,7 +8,7 @@ const { spawn, spawnSync } = require('child_process');
 const clone = require('git-clone');
 const fs = require('fs');
 
-export default function (options) {
+export default function(options) {
   const welcomeMessage = 'ws init - the simplest way to install Wingsuit.';
   logger.log(chalk.inverse(`\n ${welcomeMessage} \n`));
   const useYarn = Boolean(options.useNpm !== true) && hasYarn();
@@ -31,7 +31,7 @@ export default function (options) {
   spawnSync('pwd', [], cmdOptions);
 
   // Removes the \n from the stringified buffer
-  const extractHash = (buffer) => {
+  const extractHash = buffer => {
     const arr = buffer.toString('utf8').split('\n');
     return arr[0];
   };
@@ -58,7 +58,7 @@ export default function (options) {
     }
     const pkgFile = `${npmOptions.gitFolder}/starter-kits/${npmOptions.starterKit}/package.json`;
     const pkg = JSON.parse(fs.readFileSync(pkgFile));
-    Object.keys(pkg.devDependencies).forEach((key) => {
+    Object.keys(pkg.devDependencies).forEach(key => {
       if (key.indexOf('@wingsuit-designsystem/') === 0) {
         pkg.devDependencies[key] = `^${pkg.devDependencies[key]}`;
       }

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,6 +1,6 @@
 const logger = console;
 const pkg = require('../package.json');
 
-export default function (options) {
+export default function(options) {
   logger.log(`Wingsuit Version: ${pkg.version}`);
 }

--- a/packages/core/__tests__/presetManager.test.ts
+++ b/packages/core/__tests__/presetManager.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { resolveConfig, PresetManager } from '../src/index';
 
 const config = {
-  webpack: (appConfig) => {
+  webpack: appConfig => {
     return { testWebpack: true };
   },
   webpackFinal: (appConfig, webpack) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,7 @@ export function getAppNames(wingsuitConfig: any = null, type = '') {
     wingsuitConfig != null ? wingsuitConfig : require(`${process.cwd()}/wingsuit.config`);
   const mergedConfig = merge(configStub.wingsuit, projectConfig);
   const names: string[] = [];
-  Object.keys(mergedConfig.apps).forEach((name) => {
+  Object.keys(mergedConfig.apps).forEach(name => {
     if (type === '' || type === mergedConfig.apps[name].type) {
       names.push(name);
     }

--- a/packages/core/src/server/plugins/Svg2JsonPlugin.ts
+++ b/packages/core/src/server/plugins/Svg2JsonPlugin.ts
@@ -20,7 +20,7 @@ export default class Svg2JsonPlugin {
       const filename = this.targetJsonFlename;
       const { svgFolderPath } = this;
       const svgs: string[] = [];
-      fs.readdirSync(svgFolderPath).forEach((file) => {
+      fs.readdirSync(svgFolderPath).forEach(file => {
         svgs.push(path.basename(file, '.svg'));
       });
       const output = { svgs };
@@ -31,7 +31,7 @@ export default class Svg2JsonPlugin {
         if (readerr) console.error(readerr, `Creating ${path.basename(filename)}!`);
         // Only write output if there is a difference or non-existent target file
         if (jsondiff.diff(existingJson, output)) {
-          fs.outputJson(filename, output, (writeerr) => {
+          fs.outputJson(filename, output, writeerr => {
             // eslint-disable-next-line no-console
             if (writeerr) console.error(writeerr);
           });

--- a/packages/core/src/server/plugins/Svg2JsonPlugin.ts
+++ b/packages/core/src/server/plugins/Svg2JsonPlugin.ts
@@ -27,12 +27,10 @@ export default class Svg2JsonPlugin {
       // Plugins are null after restoring from file system.
       // Infinite loop.
       fs.readJson(filename, (readerr, existingJson) => {
-        // eslint-disable-next-line no-console
         if (readerr) console.error(readerr, `Creating ${path.basename(filename)}!`);
         // Only write output if there is a difference or non-existent target file
         if (jsondiff.diff(existingJson, output)) {
           fs.outputJson(filename, output, writeerr => {
-            // eslint-disable-next-line no-console
             if (writeerr) console.error(writeerr);
           });
         }

--- a/packages/core/src/server/presets/assets.ts
+++ b/packages/core/src/server/presets/assets.ts
@@ -89,7 +89,7 @@ export function webpack(appConfig: AppConfig) {
 export function webpackFinal(appConfig: AppConfig, config: any): {} {
   if (appConfig.type === 'storybook') {
     // eslint-disable-next-line no-param-reassign
-    config.module.rules = config.module.rules.map((data) => {
+    config.module.rules = config.module.rules.map(data => {
       if (/svg\|ico\|jpg\|/.test(String(data.test)))
         // eslint-disable-next-line no-param-reassign
         data = {};

--- a/packages/core/src/server/presets/assetsVideos.ts
+++ b/packages/core/src/server/presets/assetsVideos.ts
@@ -31,7 +31,7 @@ export function webpack(appConfig: AppConfig) {
 export function webpackFinal(appConfig: AppConfig, config: any): {} {
   if (appConfig.type === 'storybook') {
     // eslint-disable-next-line no-param-reassign
-    config.module.rules = config.module.rules.map((data) => {
+    config.module.rules = config.module.rules.map(data => {
       if (/mp4\|webm\|wav/.test(String(data.test)))
         // eslint-disable-next-line no-param-reassign
         data = {};

--- a/packages/pattern/__int_tests__/twigRenderEngine.test.ts
+++ b/packages/pattern/__int_tests__/twigRenderEngine.test.ts
@@ -8,7 +8,7 @@ const renderEngine = require('../src/twigRenderEngine');
 
 const renderer = new TwingRenderer();
 const loader = new TwingLoaderFilesystem();
-Object.keys(namespaces).forEach((namespace) => {
+Object.keys(namespaces).forEach(namespace => {
   loader.setPaths(namespaces[namespace], namespace);
 });
 

--- a/packages/pattern/src/PatternStorage.ts
+++ b/packages/pattern/src/PatternStorage.ts
@@ -63,7 +63,7 @@ export default class PatternStorage implements IPatternStorage {
 
   createDefinitionsFromMultiContext(any): void {
     if (Array.isArray(any) === true) {
-      any.forEach((context) => {
+      any.forEach(context => {
         this.createDefinitionsFromContext(context);
       });
     } else {
@@ -75,7 +75,7 @@ export default class PatternStorage implements IPatternStorage {
     if (this.definitions.patterns == null) {
       this.definitions.patterns = {};
     }
-    context.keys().forEach((key) => {
+    context.keys().forEach(key => {
       if (key.includes('__tests__') === false && key.includes('__int_tests__') === false) {
         const data = context(key);
         if (data.wingsuit != null && typeof data.wingsuit.patternDefinition === 'object') {
@@ -96,7 +96,7 @@ export default class PatternStorage implements IPatternStorage {
             }
           }
 
-          Object.keys(patternDefinition).forEach((pattern_key) => {
+          Object.keys(patternDefinition).forEach(pattern_key => {
             if (parameters !== null) {
               patternDefinition[pattern_key].parameters = parameters;
             }
@@ -112,7 +112,7 @@ export default class PatternStorage implements IPatternStorage {
 
   findTwigByNamespace(namespace): any | null {
     let foundResource = null;
-    Object.keys(this.twigResources).forEach((key) => {
+    Object.keys(this.twigResources).forEach(key => {
       if (key.trim() === namespace.trim()) {
         foundResource = this.twigResources[key];
       }
@@ -126,20 +126,20 @@ export default class PatternStorage implements IPatternStorage {
   }
 
   createGlobalsFromContext(context): void {
-    context.keys().forEach((key) => {
+    context.keys().forEach(key => {
       const data = context(key);
-      Object.keys(data).forEach((valueKey) => {
+      Object.keys(data).forEach(valueKey => {
         this.addGlobal(valueKey, data[valueKey]);
       });
     });
   }
 
   createTwigStorageFromContext(context): void {
-    context.keys().forEach((key) => {
+    context.keys().forEach(key => {
       const pathAry = key.replace('./', '').split('/');
       const folderName = pathAry[0];
       let mappedNamespace = '';
-      Object.keys(this.namespaces).forEach((namespace) => {
+      Object.keys(this.namespaces).forEach(namespace => {
         const namespaceMap = this.namespaces[namespace].split('/');
         if (namespaceMap[namespaceMap.length - 1] === folderName) {
           mappedNamespace = namespace;
@@ -153,7 +153,7 @@ export default class PatternStorage implements IPatternStorage {
   getTwigResources(): {} {
     const resources = this.twigResources;
     const result = {};
-    Object.keys(resources).forEach((key) => {
+    Object.keys(resources).forEach(key => {
       result[key] = resources[key].default;
     });
     return result;

--- a/packages/pattern/src/Setting.ts
+++ b/packages/pattern/src/Setting.ts
@@ -12,7 +12,7 @@ export default class Setting extends Property {
 
   public getOptionKeyByLabel(label): string {
     let optionKey = '';
-    Object.keys(this.options).forEach((key) => {
+    Object.keys(this.options).forEach(key => {
       if (this.options[key] === label) {
         optionKey = key;
       }

--- a/packages/pattern/src/TwigAttribute.ts
+++ b/packages/pattern/src/TwigAttribute.ts
@@ -9,7 +9,7 @@ export default class TwigAttribute {
     this.attributes = new Map();
     if (attributes !== '') {
       const attrs = htmlAttributeParser(`<div ${attributes}></div>`).attributes;
-      Object.keys(attrs).forEach((key) => {
+      Object.keys(attrs).forEach(key => {
         if (key === 'class') {
           this.attributes.set(key, attrs[key].split(' '));
         } else {
@@ -82,7 +82,7 @@ export default class TwigAttribute {
 
   toString() {
     let output = '';
-    Array.from(this.attributes.keys()).forEach((key) => {
+    Array.from(this.attributes.keys()).forEach(key => {
       let attributeValue = null;
       if (typeof this.attributes.get(key) === 'object' && Array.isArray(this.attributes.get(key))) {
         attributeValue = this.attributes.get(key).join(' ');

--- a/packages/pattern/src/TwingRenderer.ts
+++ b/packages/pattern/src/TwingRenderer.ts
@@ -44,8 +44,8 @@ export class TwingRenderer implements IRenderer {
           if (this.cache[cacheKey]) {
             return Promise.resolve(this.cache[cacheKey]);
           }
-          return new Promise((resolve) => {
-            renderPatternPreview(patternId, variantId, variables).then((output) => {
+          return new Promise(resolve => {
+            renderPatternPreview(patternId, variantId, variables).then(output => {
               this.cache[cacheKey] = output;
               resolve(output);
             });

--- a/packages/pattern/src/twigExtensions.ts
+++ b/packages/pattern/src/twigExtensions.ts
@@ -13,7 +13,7 @@ export function without(element, ...args) {
     return [];
   }
   if (element instanceof TwigAttribute) {
-    args.forEach((key) => {
+    args.forEach(key => {
       element.removeAttribute(key);
     });
   }
@@ -28,7 +28,7 @@ export function twigItok() {
 
 export function twigUuid() {
   return Promise.resolve(
-    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
       // eslint-disable-next-line no-bitwise
       const r = (Math.random() * 16) | 0;
       // eslint-disable-next-line no-bitwise

--- a/packages/pattern/src/twigRenderEngine.ts
+++ b/packages/pattern/src/twigRenderEngine.ts
@@ -108,10 +108,10 @@ export async function renderPatternPreview(
           ...previewRenderedVariables,
         };
         renderPattern(patternId, variantId, finalVariables)
-          .then((output) => {
+          .then(output => {
             resolve(output);
           })
-          .catch((error) => {
+          .catch(error => {
             resolve(error);
           });
       });

--- a/packages/storybook/src/behaviors.tsx
+++ b/packages/storybook/src/behaviors.tsx
@@ -1,29 +1,33 @@
-import React from 'react';
-import { useEffect } from '@storybook/client-api';
-
 declare const window: Window;
 
 let behaviorName;
 let beahviorsInitialized = false;
+
 export function isInit() {
   return beahviorsInitialized;
 }
+
 export function init(pbehaviorName) {
   if (beahviorsInitialized === false) {
     // @ts-ignore
-    window[pbehaviorName] = { behaviors: {} };
+    window[pbehaviorName] = {behaviors: {}};
     behaviorName = pbehaviorName;
   }
   beahviorsInitialized = true;
 }
 
 export function attachBehaviorDecorator(storyFn) {
+  console.error('attachBehaviorDecorator in your apps/storybook/preview.js is deprecated.');
+  console.error('Please replace your preview.js with https://github.com/wingsuit-designsystem/wingsuit/blob/master/starter-kits/tailwind/apps/storybook/preview.js.');
+
   return (
-    <div>
-      {storyFn()}
-      {useEffect(() => BehaviorExecutor.attachBehaviors({}, {}), [])}
-    </div>
+    storyFn()
   );
+
+}
+
+export function attachBehaviors(context: any, settings: {}) {
+  BehaviorExecutor.attachBehaviors(context, settings);
 }
 
 class BehaviorExecutor {
@@ -35,19 +39,17 @@ class BehaviorExecutor {
     }, 0);
   }
 
-  public static attachBehaviors(context = {}, settings = {}) {
+  public static attachBehaviors(context: any, settings = {}) {
     // @ts-ignore
-    const { behaviors } = window[behaviorName];
-    window.setTimeout(() => {
-      Object.keys(behaviors).forEach((i) => {
-        if (typeof behaviors[i].attach === 'function') {
-          try {
-            behaviors[i].attach(context, settings);
-          } catch (e) {
-            BehaviorExecutor.throwError(e);
-          }
+    const {behaviors} = window[behaviorName];
+    Object.keys(behaviors).forEach((i) => {
+      if (typeof behaviors[i].attach === 'function') {
+        try {
+          behaviors[i].attach(context, settings);
+        } catch (e) {
+          BehaviorExecutor.throwError(e);
         }
-      });
-    }, 300);
+      }
+    });
   }
 }

--- a/packages/storybook/src/behaviors.tsx
+++ b/packages/storybook/src/behaviors.tsx
@@ -10,7 +10,7 @@ export function isInit() {
 export function init(pbehaviorName) {
   if (beahviorsInitialized === false) {
     // @ts-ignore
-    window[pbehaviorName] = {behaviors: {}};
+    window[pbehaviorName] = { behaviors: {} };
     behaviorName = pbehaviorName;
   }
   beahviorsInitialized = true;
@@ -18,12 +18,11 @@ export function init(pbehaviorName) {
 
 export function attachBehaviorDecorator(storyFn) {
   console.error('attachBehaviorDecorator in your apps/storybook/preview.js is deprecated.');
-  console.error('Please replace your preview.js with https://github.com/wingsuit-designsystem/wingsuit/blob/master/starter-kits/tailwind/apps/storybook/preview.js.');
-
-  return (
-    storyFn()
+  console.error(
+    'Please replace your preview.js with https://github.com/wingsuit-designsystem/wingsuit/blob/master/starter-kits/tailwind/apps/storybook/preview.js.'
   );
 
+  return storyFn();
 }
 
 export function attachBehaviors(context: any, settings: {}) {
@@ -41,8 +40,8 @@ class BehaviorExecutor {
 
   public static attachBehaviors(context: any, settings = {}) {
     // @ts-ignore
-    const {behaviors} = window[behaviorName];
-    Object.keys(behaviors).forEach((i) => {
+    const { behaviors } = window[behaviorName];
+    Object.keys(behaviors).forEach(i => {
       if (typeof behaviors[i].attach === 'function') {
         try {
           behaviors[i].attach(context, settings);

--- a/packages/storybook/src/behaviors.tsx
+++ b/packages/storybook/src/behaviors.tsx
@@ -39,6 +39,12 @@ class BehaviorExecutor {
   }
 
   public static attachBehaviors(context: any, settings = {}) {
+    if (beahviorsInitialized === false) {
+      console.error(
+        "attachBehavior is not initialized. Call initJsBehaviors('Drupal'); in your preview.js."
+      );
+      return;
+    }
     // @ts-ignore
     const { behaviors } = window[behaviorName];
     Object.keys(behaviors).forEach(i => {

--- a/packages/storybook/src/components/PatternPreview.tsx
+++ b/packages/storybook/src/components/PatternPreview.tsx
@@ -5,11 +5,11 @@ import { attachBehaviors } from '../behaviors';
 type Props = { patternId?; variantId?; variant? };
 
 const PatternPreview: FunctionComponent<Props> = ({
-                                                    patternId,
-                                                    variantId,
-                                                    variant,
-                                                    ...variables
-                                                  }) => {
+  patternId,
+  variantId,
+  variant,
+  ...variables
+}) => {
   const [rendered, setRendered] = useState('');
   const finalPatternId = variant !== null ? variant.getPattern().getId() : patternId;
   const finalVariantId = variant !== null ? variant.getId() : variantId;
@@ -22,7 +22,7 @@ const PatternPreview: FunctionComponent<Props> = ({
           setRendered(output);
         }
       })
-      .catch((error) => {
+      .catch(error => {
         setRendered(`Error: ${error.message}`);
       });
     return () => {
@@ -33,11 +33,11 @@ const PatternPreview: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (!rendered) return;
-    attachBehaviors(global.window.document, {})
-  }, [rendered])
+    attachBehaviors(global.window.document, {});
+  }, [rendered]);
 
   // eslint-disable-next-line react/no-danger
-  const element = <div dangerouslySetInnerHTML={{__html: rendered}}/>;
+  const element = <div dangerouslySetInnerHTML={{ __html: rendered }} />;
   return element;
 };
 

--- a/packages/storybook/src/components/PatternPreview.tsx
+++ b/packages/storybook/src/components/PatternPreview.tsx
@@ -1,14 +1,15 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { renderer } from '@wingsuit-designsystem/pattern';
+import { attachBehaviors } from '../behaviors';
 
 type Props = { patternId?; variantId?; variant? };
 
 const PatternPreview: FunctionComponent<Props> = ({
-  patternId,
-  variantId,
-  variant,
-  ...variables
-}) => {
+                                                    patternId,
+                                                    variantId,
+                                                    variant,
+                                                    ...variables
+                                                  }) => {
   const [rendered, setRendered] = useState('');
   const finalPatternId = variant !== null ? variant.getPattern().getId() : patternId;
   const finalVariantId = variant !== null ? variant.getId() : variantId;
@@ -30,8 +31,14 @@ const PatternPreview: FunctionComponent<Props> = ({
     };
   }, [patternId, variantId, JSON.stringify(variables)]);
 
+  useEffect(() => {
+    if (!rendered) return;
+    attachBehaviors(global.window.document, {})
+  }, [rendered])
+
   // eslint-disable-next-line react/no-danger
-  return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+  const element = <div dangerouslySetInnerHTML={{__html: rendered}}/>;
+  return element;
 };
 
 PatternPreview.displayName = 'PatternPreview';

--- a/packages/storybook/src/components/RenderTwig.tsx
+++ b/packages/storybook/src/components/RenderTwig.tsx
@@ -11,7 +11,7 @@ const RenderTwig: FunctionComponent<Props> = ({ data, ...variables }) => {
       .then((output: string) => {
         setRendered(output);
       })
-      .catch((error) => {
+      .catch(error => {
         setRendered(error.message);
       });
   }, [data, JSON.stringify(variables)]);

--- a/packages/storybook/src/docs/PatternProperties.tsx
+++ b/packages/storybook/src/docs/PatternProperties.tsx
@@ -18,7 +18,7 @@ export const PatternProperties: FC<Props> = (props: Props) => {
   const { variant } = props;
   const fields = variant.getFields();
   properties.Fields = { name: 'Fields', rows: {} };
-  Object.keys(fields).forEach((key) => {
+  Object.keys(fields).forEach(key => {
     const field = fields[key];
     if (field.isEnable()) {
       properties.Fields.rows[key] = {
@@ -32,7 +32,7 @@ export const PatternProperties: FC<Props> = (props: Props) => {
   });
   const settings = variant.getSettings();
   properties.Settings = { name: 'Settings', rows: {} };
-  Object.keys(settings).forEach((key) => {
+  Object.keys(settings).forEach(key => {
     const setting = settings[key];
     if (setting.isEnable()) {
       properties.Settings.rows[key] = {

--- a/packages/storybook/src/drupal.tsx
+++ b/packages/storybook/src/drupal.tsx
@@ -2,8 +2,6 @@
 @deprecated
 Use behaviors instead.
  */
-import React from 'react';
-import { useEffect } from '@storybook/client-api';
 
 interface DrupalWindow extends Window {
   Drupal: Drupal;
@@ -14,12 +12,12 @@ declare const window: DrupalWindow;
 window.Drupal = { behaviors: {} };
 
 export function drupalAttachBehaviorDecorator(storyFn) {
-  return (
-    <div>
-      {storyFn()}
-      {useEffect(() => Drupal.attachBehaviors({}, {}), [])}
-    </div>
+  console.error('attachBehaviorDecorator in your apps/storybook/preview.js is deprecated.');
+  console.error(
+    'Please replace your preview.js with https://github.com/wingsuit-designsystem/wingsuit/blob/master/starter-kits/tailwind/apps/storybook/preview.js.'
   );
+
+  return storyFn();
 }
 
 class Drupal {
@@ -35,7 +33,7 @@ class Drupal {
     const { behaviors } = window.Drupal;
 
     window.setTimeout(() => {
-      Object.keys(behaviors).forEach((i) => {
+      Object.keys(behaviors).forEach(i => {
         if (typeof behaviors[i].attach === 'function') {
           try {
             behaviors[i].attach(context, settings);

--- a/packages/storybook/src/index.tsx
+++ b/packages/storybook/src/index.tsx
@@ -172,6 +172,7 @@ export { drupalAttachBehaviorDecorator } from './drupal';
 export {
   isInit as isInitDecorator,
   init as initDecorator,
+  init as initJsBehaviors,
   attachBehaviorDecorator,
 } from './behaviors';
 export { default as RenderTwig } from './components/RenderTwig';

--- a/presets/tailwind/src/plugins/Tailwind2JsonPlugin.ts
+++ b/presets/tailwind/src/plugins/Tailwind2JsonPlugin.ts
@@ -25,12 +25,10 @@ export default class Tailwind2JsonPlugin {
       // Plugins are null after restoring from file system.
       // Infinite loop.
       fs.readJson(filename, (readerr, existingJson) => {
-        // eslint-disable-next-line no-console
         if (readerr) console.error(readerr, `Creating ${path.basename(filename)}!`);
         // Only write output if there is a difference or non-existent target file
         if (jsondiff.diff(existingJson, output)) {
-          fs.outputJson(filename, output, (writeerr) => {
-            // eslint-disable-next-line no-console
+          fs.outputJson(filename, output, writeerr => {
             if (writeerr) console.error(writeerr);
           });
         }

--- a/presets/tailwind2/src/plugins/Tailwind2JsonPlugin.ts
+++ b/presets/tailwind2/src/plugins/Tailwind2JsonPlugin.ts
@@ -25,12 +25,10 @@ export default class Tailwind2JsonPlugin {
       // Plugins are null after restoring from file system.
       // Infinite loop.
       fs.readJson(filename, (readerr, existingJson) => {
-        // eslint-disable-next-line no-console
         if (readerr) console.error(readerr, `Creating ${path.basename(filename)}!`);
         // Only write output if there is a difference or non-existent target file
         if (jsondiff.diff(existingJson, output)) {
-          fs.outputJson(filename, output, (writeerr) => {
-            // eslint-disable-next-line no-console
+          fs.outputJson(filename, output, writeerr => {
             if (writeerr) console.error(writeerr);
           });
         }

--- a/starter-kits/bootstrap/apps/storybook/preview.js
+++ b/starter-kits/bootstrap/apps/storybook/preview.js
@@ -1,18 +1,9 @@
-import {
-  configure,
-  initDecorator,
-  isInitDecorator,
-  attachBehaviorDecorator,
-} from '@wingsuit-designsystem/storybook';
-import { addDecorator, addParameters } from '@storybook/react';
+import { configure, initJsBehaviors } from '@wingsuit-designsystem/storybook';
+import { addParameters } from '@storybook/react';
 
-const namespaces = require('wsdesignsystem/namespaces.js');
+const namespaces = require('wsdesignsystem/namespaces');
 
-console.log(namespaces);
-if (isInitDecorator() === false) {
-  initDecorator('Drupal');
-  addDecorator(attachBehaviorDecorator);
-}
+initJsBehaviors('Drupal');
 
 addParameters({
   options: {

--- a/starter-kits/bootstrap/source/default/patterns/01-atoms/button/button.behavior.js
+++ b/starter-kits/bootstrap/source/default/patterns/01-atoms/button/button.behavior.js
@@ -1,0 +1,5 @@
+Drupal.behaviors.button = {
+  attach() {
+    console.log('ATTACH');
+  },
+};

--- a/starter-kits/bootstrap/source/default/patterns/01-atoms/button/index.js
+++ b/starter-kits/bootstrap/source/default/patterns/01-atoms/button/index.js
@@ -6,5 +6,6 @@ import 'protons';
 
 // Module template
 import './button.twig';
+import './button.behavior';
 
 export const name = 'button';

--- a/starter-kits/tailwind/apps/storybook/preview.js
+++ b/starter-kits/tailwind/apps/storybook/preview.js
@@ -1,17 +1,9 @@
-import {
-  configure,
-  initDecorator,
-  isInitDecorator,
-  attachBehaviorDecorator,
-} from '@wingsuit-designsystem/storybook';
-import { addDecorator, addParameters } from '@storybook/react';
+import { configure, initJsBehaviors } from '@wingsuit-designsystem/storybook';
+import { addParameters } from '@storybook/react';
 
 const namespaces = require('wsdesignsystem/namespaces');
 
-if (isInitDecorator() === false) {
-  initDecorator('Drupal');
-  addDecorator(attachBehaviorDecorator);
-}
+initJsBehaviors('Drupal');
 
 addParameters({
   options: {


### PR DESCRIPTION
This pr changes the way attachBehaviors is called.
Currently attachBehaviors is implemented as Storybook decorator.
Now attachBehavior is called after the react component is completely rendered. Also after changing props via knobs. 
No hacky setTimeout is needed any more.

