### PR TITLE
Fix SVG icon example

### DIFF
--- a/docs/src/pages/assets/svg/index.md
+++ b/docs/src/pages/assets/svg/index.md
@@ -16,7 +16,7 @@ Wingsuit generates an SVG sprite map for every SVG located in an `icons` folder.
 To render the icons include the `svg atom` in your Twig template: 
 
 ```twig
-{% include "@atoms/svg/svg.wig" with {"variant": 'icon', icon: "icon" }
+{% include "@atoms/svg/svg.twig" with {"variant": 'icon', icon: "icon" }
 ```
 
 ## Multiple SVG spritemaps.


### PR DESCRIPTION
Add one missing letter to the SVG icon example.