### PR TITLE
Use tailwindcss core JIT instead of @tailwindcss/jit package.

### DIFF
--- a/starter-kits/tailwind/package.json
+++ b/starter-kits/tailwind/package.json
@@ -45,7 +45,6 @@
     "@storybook/linter-config": "^2.5.0",
     "@storybook/react": "^6.1.0",
     "@storybook/storybook-deployer": "^2.8.7",
-    "@tailwindcss/jit": "^0.1.18",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
     "@wingsuit-designsystem/cli": "1.0.3",

--- a/starter-kits/tailwind/postcss.config.js
+++ b/starter-kits/tailwind/postcss.config.js
@@ -1,5 +1,4 @@
-const useJit = true;
-const tailwind = useJit ? require('@tailwindcss/jit') : require('tailwindcss');
+const tailwind = require('tailwindcss');
 const nested = require('postcss-nested');
 const autoprefixer = require('autoprefixer');
 

--- a/starter-kits/tailwind/tailwind.config.js
+++ b/starter-kits/tailwind/tailwind.config.js
@@ -5,13 +5,15 @@ const typography = require('@tailwindcss/typography')({
 });
 
 module.exports = {
+  mode: 'jit',
   important: false,
   darkMode: 'class',
-  purge: {
-    layers: ['utilities'],
-    content: ['./source/**/*.twig', './source/**/*.yml', './apps/**/*.twig'],
-    whitelist: ['bg-red-500', 'px-4'],
-  },
+  purge: [
+    './safelist.txt',
+    './source/**/*.twig',
+    './source/**/*.yml',
+    './apps/**/*.twig'
+  ],
   theme: {
     colors: {
       transparent: 'transparent',


### PR DESCRIPTION
According to https://blog.tailwindcss.com/tailwindcss-2-1 there will be no further development of https://github.com/tailwindlabs/tailwindcss-jit and users are encouraged to use the JIT compiler in the core.

This also requires some changes in `tailwind.config.js` file - I tried to translate current purge settings as closely as possible, but some docs changes will be probably needed (especially regarding to the `safelist.txt` file.