### PR TITLE
feat(presets): add compression presets

### DIFF
--- a/presets/compression/.gitignore
+++ b/presets/compression/.gitignore
@@ -1,0 +1,29 @@
+# Compiled files
+dist/
+pattern2yml/dist
+_icons-generated.scss
+dependencyGraph.json
+patterns.zip
+
+# OS generated files
+*.swp
+.DS_Store
+.DS_Store?
+._.DS_Store
+._.DS_Store?
+
+# Dependencies
+node_modules
+
+
+# Generated files
+*.sass-cache/
+.eslintcache
+*unison.*
+
+#IDE plugins
+.idea
+
+# Errors
+npm-debug.log
+php_errors.log

--- a/presets/compression/package.json
+++ b/presets/compression/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@wingsuit-designsystem/preset-compression",
+  "version": "1.1.0-alpha.1",
+  "description": "Wingsuit Compression preset.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wingsuit-designsystem/wingsuit.git"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "bin/**/*",
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts",
+    "ts3.5/**/*"
+  ],
+  "keywords": [
+    "Storybook",
+    "Atomic Design",
+    "Tailwind"
+  ],
+  "author": "Pascal Glass",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wingsuit-designsystem/wingsuit/issues"
+  },
+  "homepage": "https://github.com/wingsuit-designsystem/wingsuit/tools#readme",
+  "dependencies": {
+    "@gfx/zopfli": "^1.0.15",
+    "@wingsuit-designsystem/core": "1.1.0-alpha.1",
+    "compression-webpack-plugin": "^6.1.1",
+    "zlib": "^1.0.5"
+  },
+  "scripts": {
+    "prepare": "node ../../scripts/prepare.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "bfeff58b8f6e6ace1c28f31ad67d75d6f18ee5a4"
+}

--- a/presets/compression/src/index.ts
+++ b/presets/compression/src/index.ts
@@ -1,0 +1,79 @@
+import { AppConfig } from '@wingsuit-designsystem/core';
+
+// node modules
+const zlib = require('zlib');
+const zopfli = require('@gfx/zopfli');
+
+// webpack plugins
+const CompressionPlugin = require('compression-webpack-plugin');
+
+/**
+ * Exposing options, which can be changed in the wingsuit.config.js.
+ */
+interface CompressionConfig {
+  gzipEnabled: boolean;
+  brotliEnabled: boolean;
+  fileName: string;
+}
+
+/**
+ * Give the preset a name, so we can access it in the wingsuit.config.js.
+ * @param {AppConfig} appConfig
+ * @returns {string}
+ */
+export function name(appConfig: AppConfig) {
+  return 'compression';
+}
+
+/**
+ * Setting default values.
+ * @param {AppConfig} appConfig
+ * @returns {CompressionConfig}
+ */
+export function defaultConfig(appConfig: AppConfig): CompressionConfig {
+  return {
+    gzipEnabled: true,
+    brotliEnabled: true,
+    fileName: '[path][base]',
+  };
+}
+
+export function webpack(appConfig: AppConfig, config: CompressionConfig) {
+  if (appConfig.environment === 'production') {
+    return {
+      // Allow falsy values in plugins array see https://github.com/webpack/webpack/issues/5493#issuecomment-321705298
+      plugins: [
+        config.gzipEnabled && (
+          new CompressionPlugin({
+            algorithm(input, compressionOptions, callback) {
+              return zopfli.gzip(input, compressionOptions, callback);
+            },
+            compressionOptions: {
+              numiterations: 15,
+              level: 9,
+            },
+            deleteOriginalAssets: false,
+            filename: `${config.fileName}.gz`,
+            minRatio: 0.8,
+            test: /\.(js|css|html)$/,
+          })
+        ),
+        config.brotliEnabled && (
+          new CompressionPlugin({
+            algorithm: 'brotliCompress',
+            compressionOptions: {
+              params: {
+                [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+              },
+            },
+            deleteOriginalAssets: false,
+            filename: `${config.fileName}.br`,
+            minRatio: 0.8,
+            test: /\.(js|css|html)$/,
+          })
+        ),
+      ].filter(Boolean),
+    };
+  }
+  return {};
+}

--- a/presets/compression/tsconfig.json
+++ b/presets/compression/tsconfig.json
@@ -1,0 +1,12 @@
+
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["__tests__/**/*", "__int_tests__/**/*"]
+}


### PR DESCRIPTION
This preset adds compression for css, js and html files. Following props are exposed to be used in the wingsuit.config.yml

| Prop          | Type                                | Desc                                                                                                                                 |
|---------------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
| gzipEnabled   | {boolean \| default: true}          | use gzip compression algorithm/function                                                                                              |
| brotliEnabled | {boolean \| default: true}          | use brotli compression algorithm/function                                                                                            |
| fileName      | {string \| default: '[path][base]'} | target asset filename [see for more information](https://github.com/webpack-contrib/compression-webpack-plugin/tree/v6.1.1#filename) |

Example configuration:
```
const namespaces = require('./source/default/namespaces');

module.exports = {
  presets: [
    '@wingsuit-designsystem/preset-tailwind2',
    '@wingsuit-designsystem/preset-postcss8',
    '@wingsuit-designsystem/preset-compression',
  ],
  parameters: {
    compression: {
      gzipEnabled: true,
      brotliEnabled: false,
    },
  },
  designSystems: {
    default: {
      namespaces,
    },
  },
};
```

The optimized files are only generated when running the build process of drupal.