### PR TITLE
feat(presets): add imagemin preset

### DIFF
--- a/presets/imagemin/.gitignore
+++ b/presets/imagemin/.gitignore
@@ -1,0 +1,29 @@
+# Compiled files
+dist/
+pattern2yml/dist
+_icons-generated.scss
+dependencyGraph.json
+patterns.zip
+
+# OS generated files
+*.swp
+.DS_Store
+.DS_Store?
+._.DS_Store
+._.DS_Store?
+
+# Dependencies
+node_modules
+
+
+# Generated files
+*.sass-cache/
+.eslintcache
+*unison.*
+
+#IDE plugins
+.idea
+
+# Errors
+npm-debug.log
+php_errors.log

--- a/presets/imagemin/package.json
+++ b/presets/imagemin/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@wingsuit-designsystem/preset-imagemin",
+  "version": "1.1.0-alpha.1",
+  "description": "Wingsuit image optimization preset.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wingsuit-designsystem/wingsuit.git"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "bin/**/*",
+    "dist/**/*",
+    "README.md",
+    "*.js",
+    "*.d.ts",
+    "ts3.5/**/*"
+  ],
+  "keywords": [
+    "Storybook",
+    "Atomic Design",
+    "Tailwind"
+  ],
+  "author": "Pascal Glass",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wingsuit-designsystem/wingsuit/issues"
+  },
+  "homepage": "https://github.com/wingsuit-designsystem/wingsuit/tools#readme",
+  "dependencies": {
+    "@wingsuit-designsystem/core": "1.1.0-alpha.0",
+    "imagemin-gifsicle": "^6.0.0",
+    "imagemin-mozjpeg": "^8.0.0",
+    "imagemin-optipng": "^6.0.0",
+    "imagemin-svgo": "^7.0.0",
+    "imagemin-webp-webpack-plugin": "^3.1.0",
+    "imagemin-webpack-plugin": "^2.4.2"
+  },
+  "scripts": {
+    "prepare": "node ../../scripts/prepare.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "bfeff58b8f6e6ace1c28f31ad67d75d6f18ee5a4"
+}

--- a/presets/imagemin/src/index.ts
+++ b/presets/imagemin/src/index.ts
@@ -1,0 +1,63 @@
+import * as path from 'path';
+import { AppConfig } from '@wingsuit-designsystem/core';
+
+// webpack plugins
+const ImageminPlugin = require('imagemin-webpack-plugin').default;
+const ImageminWebpWebpackPlugin = require('imagemin-webp-webpack-plugin');
+
+interface ImageminConfig {
+  webpEnabled: boolean;
+}
+
+export function name(appConfig: AppConfig) {
+  return 'imagemin';
+}
+
+export function defaultConfig(appConfig: AppConfig): ImageminConfig {
+  return {
+    webpEnabled: true,
+  };
+}
+
+export function webpack(appConfig: AppConfig, config: ImageminConfig) {
+  return {
+    plugins: [
+      new ImageminPlugin({
+        disable: process.env.NODE_ENV !== 'production',
+        test: path.join(appConfig.assetBundleFolder, 'images/**'),
+        exclude: path.join(appConfig.assetBundleFolder, 'images/spritemap.svg'),
+        cacheFolder: path.join(appConfig.absRootPath, '.cache'),
+        plugins: [
+          // eslint-disable-next-line global-require
+          require('imagemin-gifsicle')({
+            interlaced: true,
+          }),
+          // eslint-disable-next-line global-require
+          require('imagemin-mozjpeg')({
+            progressive: true,
+            arithmetic: false,
+          }),
+          // eslint-disable-next-line global-require
+          require('imagemin-optipng')({
+            optimizationLevel: 5,
+          }),
+          // eslint-disable-next-line global-require
+          require('imagemin-svgo')({
+            plugins: [{ convertPathData: false }],
+          }),
+        ],
+      }),
+      config.webpEnabled && (
+        new ImageminWebpWebpackPlugin({
+          config: [
+            {
+              test: /\.(jpe?g|png)/,
+            },
+          ],
+          silent: false,
+          detailedLogs: true,
+        })
+      )
+    ].filter(Boolean),
+  };
+}

--- a/presets/imagemin/tsconfig.json
+++ b/presets/imagemin/tsconfig.json
@@ -1,0 +1,12 @@
+
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["__tests__/**/*", "__int_tests__/**/*"]
+}


### PR DESCRIPTION
This preset compresses images (gif, png, svg, jpeg) and generates webP variants out of it. Following prop is exposed to be used in the wingsuit.config.yml

| Prop        | Type                       | Desc                             |
|-------------|----------------------------|----------------------------------|
| webpEnabled | {Boolean \| default: true} | Generate webP variants of images |

Example configuration:
```
const namespaces = require('./source/default/namespaces');

module.exports = {
  presets: [
    '@wingsuit-designsystem/preset-tailwind2',
    '@wingsuit-designsystem/preset-postcss8',
    '@wingsuit-designsystem/preset-imagemin',
  ],
  parameters: {
    imagemin: {
      webpEnabled: false,
    },
  },
  designSystems: {
    default: {
      namespaces,
    },
  },
};
```

When `webpEnabled` is set to true, webP variants will also be generated in development mode to ensure webP can also be used within wingsuit while developing. Further optimizations of images only run in production mode. A .cache folder will be created at the root level of the application to speed up further production builds.