### PR TITLE
Update package.json

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -45,7 +45,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-syntax-highlighter": "^15.3.1s"
+    "react-syntax-highlighter": "^15.3.1"
   },
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"


### PR DESCRIPTION
the leading 's' in react-syntax-highlighter version results in yarn failing with:
```
YN0001: │ Error: react-syntax-highlighter@^15.3.1s isn't supported by any available resolver
    at Xc.getResolverByDescriptor (/Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:294:5330)
    at Xc.bindDescriptor (/Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:294:4719)
    at p (/Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:303:6959)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Promise.all (index 20)
    at async Promise.all (index 0)
    at async Fe.resolveEverything (/Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:303:8166)
    at async /Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:306:2135
    at async Se.startTimerPromise (/Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:275:3730)
    at async Fe.install (/Users/wiwo/spielwiese/test/.yarn/releases/yarn-berry.cjs:306:2074)
```