### PR TITLE
fix(build): Fix baseline build race for pattern-react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ cypress/videos
 cypress/screenshots
 packages/wingsuit/yarn.lock
 .fleet
+.nx
+packages/pattern/src/*.d.ts

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -175,7 +175,13 @@ function run() {
               });
           }
         } else {
-          spawn(`nx run-many --target=prepare --projects=${projects.join(',')} --nx-bail`);
+          const needsSequential =
+            projects.includes('@wingsuit-designsystem/pattern-react') &&
+            projects.includes('@wingsuit-designsystem/pattern');
+          const parallelFlag = needsSequential ? ' --parallel=1' : '';
+          spawn(
+            `nx run-many --target=prepare --projects=${projects.join(',')}${parallelFlag} --nx-bail`
+          );
         }
         process.stdout.write('\x07');
       }


### PR DESCRIPTION

  - Force sequential prepare when both @wingsuit-designsystem/pattern and pattern-react are built in the same batch to avoid TS resolution errors.
  - Ignore Nx cache and generated pattern src .d.ts artifacts to keep the repo clean.
